### PR TITLE
docs: fix Claude Code plugin install identifier in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Alternatively, run **Chat: Install Plugin From Source** from the Command Palette
 
 ```bash
 > /plugin marketplace add webmaxru/ai-native-dev
-> /plugin install web-ai-skills@webmaxru/ai-native-dev
+> /plugin install web-ai-skills@webmaxru-ai-native-dev
 ```
 
 ### Install Individual Skills


### PR DESCRIPTION
## Summary
- Fix the Claude Code install command in `README.md` so it matches the actual marketplace identifier registered by `/plugin marketplace add webmaxru/ai-native-dev`
- `/plugin marketplace add webmaxru/ai-native-dev` registers the marketplace as `webmaxru-ai-native-dev` (hyphen-separated, from the marketplace catalog's `name` field), so the install command must reference that identifier rather than the GitHub path

## Test plan
- [ ] Run `/plugin marketplace add webmaxru/ai-native-dev` in Claude Code
- [ ] Run `/plugin install web-ai-skills@webmaxru-ai-native-dev` and confirm the plugin installs successfully