### PR TITLE
Add Semantic Embedder API skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Web AI Agent Skills banner](assets/repo-banner.svg)
 
-A maintained collection of agent skills for modern browser Web AI APIs: Prompt API, Language Detector API, Translator API, Writing Assistance APIs, Proofreader API, WebMCP, and WebNN.
+A maintained collection of agent skills for modern browser Web AI APIs: Prompt API, Language Detector API, Translator API, Writing Assistance APIs, Proofreader API, Semantic Embedder API, WebMCP, and WebNN.
 
 Standards and preview implementations still shift, browser behavior changes across milestones, and many ecosystem examples go stale quickly. These skills reduce that drift so generated or assisted code stays aligned with the current public specification state instead of relying on outdated snippets or guesswork.
 
@@ -21,6 +21,7 @@ The repository follows the agentskills.io style: lean `SKILL.md` files, progress
   - [Translator API Skill](#translator-api-skill)
   - [Writing Assistance APIs Skill](#writing-assistance-apis-skill)
   - [Proofreader API Skill](#proofreader-api-skill)
+  - [Semantic Embedder API Skill](#semantic-embedder-api-skill)
   - [WebMCP Skill](#webmcp-skill)
   - [WebNN Skill](#webnn-skill)
 - [Supporting Assets](#supporting-assets)
@@ -240,6 +241,39 @@ Its support files are split by purpose:
 - `assets/proofreader-session.template.ts` for a reusable typed session wrapper template
 - `scripts/find-proofreader-targets.mjs` for deterministic scanning of likely web entry points and Proofreader API markers
 
+### Semantic Embedder API Skill
+
+`skills/semantic-embedder-api` is scoped to browser Semantic Embedder API integrations in JavaScript or TypeScript web apps. This API is an Early Preview Program (EPP) feature gated behind a manual Chrome Canary flag, not a general-availability API.
+
+Install with APM:
+
+```bash
+apm install webmaxru/web-ai-agent-skills/skills/semantic-embedder-api
+```
+
+Install with npm:
+
+```bash
+npx skills add webmaxru/web-ai-agent-skills --skill semantic-embedder-api
+```
+
+It covers:
+
+- identifying the correct browser app surface for on-device text-embedding work
+- confirming secure-context, desktop-platform, Canary-version, and EPP flag viability before code changes
+- implementing guarded `availability()` and `create()` flows with download progress handling
+- wiring single-string and batched `embed()` calls with per-call `taskType` selection for similarity, retrieval, classification, and clustering
+- validating embedding-space versioning risk, cleanup through `destroy()`, and EPP-specific compatibility limits
+
+Its support files are split by purpose:
+
+- `references/semantic-embedder-reference.md` for API surface, `taskType` semantics, batching rules, and embedding-space comparability constraints
+- `references/examples.md` for support detection, monitored creation, similarity scoring, batched retrieval indexing, and cleanup patterns
+- `references/compatibility.md` for EPP flag requirements, Canary version gates, platform limits, and versioning guidance
+- `references/troubleshooting.md` for missing globals, flag/version mismatches, misplaced `taskType` usage, and stale-embedding symptoms
+- `assets/semantic-embedder-session.template.ts` for a reusable typed session wrapper template
+- `scripts/find-semantic-embedder-targets.mjs` for deterministic scanning of likely web entry points and Semantic Embedder API markers
+
 ### WebMCP Skill
 
 `skills/webmcp` is scoped to browser WebMCP integrations in JavaScript or TypeScript web apps.
@@ -392,6 +426,14 @@ node skills/proofreader-api/scripts/find-proofreader-targets.mjs .
 ```
 
 The scanner prioritizes common browser entry points and reports existing Proofreader API markers such as `Proofreader`, `proofread()`, correction-detail options, and the `proofreader` permissions-policy token.
+
+### Scan a Workspace for Semantic Embedder Targets
+
+```bash
+node skills/semantic-embedder-api/scripts/find-semantic-embedder-targets.mjs .
+```
+
+The scanner prioritizes common browser entry points and reports existing Semantic Embedder API markers such as `SemanticEmbedder`, `.embed()`, `taskType`, and the shape of a returned `embeddings[0].values` vector.
 
 ### Scan a Workspace for WebMCP Targets
 

--- a/skills/semantic-embedder-api/SKILL.md
+++ b/skills/semantic-embedder-api/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: semantic-embedder-api
+description: Implements and debugs browser Semantic Embedder API integrations in JavaScript or TypeScript web apps. Use when adding SemanticEmbedder support checks, availability and model download flows, session creation, embed() calls for single or batched text, taskType selection for similarity, retrieval, classification, or clustering, embedding-space versioning, or Early Preview Program flag handling for on-device text embeddings. Don't use for server-side or cloud embedding APIs, vector database implementations, generic NLP pipelines, or translation, summarization, and generation tasks.
+license: MIT
+metadata:
+  author: webmaxru
+  version: "1.0"
+---
+
+# Semantic Embedder API
+
+## Procedures
+
+**Step 1: Identify the browser integration surface**
+1. Inspect the workspace for browser entry points, search or recommendation UI, retrieval-augmented-generation (RAG) flows, and any existing AI abstraction layer.
+2. Execute `node scripts/find-semantic-embedder-targets.mjs .` to inventory likely frontend files and existing Semantic Embedder API markers when a Node runtime is available.
+3. If a Node runtime is unavailable, inspect the nearest `package.json`, HTML entry point, and framework bootstrap files manually to identify the browser app boundary.
+4. If the workspace contains multiple frontend apps, prefer the app that contains the active route, component, or user-requested feature surface.
+5. If the inventory still leaves multiple plausible frontend targets, stop and ask which app should receive the Semantic Embedder API integration.
+6. If the project is not a browser web app, stop and explain that this skill does not apply.
+
+**Step 2: Confirm API viability and choose the integration shape**
+1. Read `references/semantic-embedder-reference.md` before writing code.
+2. Read `references/examples.md` when the feature needs a session wrapper, download-progress UI, batched retrieval indexing, or similarity scoring.
+3. Read `references/compatibility.md` when Early Preview Program (EPP) requirements, preview flags, Canary version gates, or platform limits matter.
+4. Read `references/troubleshooting.md` when support checks, creation, embedding, or comparison behavior fail.
+5. Verify that the feature runs in a secure `Window` context on a desktop platform; the API does not currently target mobile.
+6. Verify that the target browser is Chrome Canary at or above the milestone documented in `references/compatibility.md`, with the Semantic Embedder EPP flag enabled. Do not assume general Chrome availability.
+7. Choose the narrowest embedding shape that matches the task:
+   - single-string `embed()` for one-off similarity checks or real-time query embedding
+   - batched `embed(stringArray)` for indexing a document collection
+   - `monitor` when the UI must surface model download progress
+8. Choose a `taskType` per call based on the product use case (`semantic-similarity`, `retrieval-query`, `retrieval-document`, `classification`, `clustering`); do not omit it for production similarity or retrieval logic, because an omitted `taskType` produces an unoptimized raw-string embedding rather than a sensible default.
+9. If the feature must run in a worker, on the server, or through a cloud-only contract, stop and explain the platform mismatch.
+10. If the project uses TypeScript, add or preserve narrow typings for the Semantic Embedder API surface used by the feature.
+
+**Step 3: Implement a guarded session wrapper**
+1. Read `assets/semantic-embedder-session.template.ts` and adapt it to the framework, state model, and file layout in the workspace.
+2. Centralize support checks around `globalThis.isSecureContext` and `SemanticEmbedder`.
+3. Gate session creation behind `SemanticEmbedder.availability()` before calling `SemanticEmbedder.create()`.
+4. Treat `availability()` as a capability check, not a guarantee that creation will succeed without download time, flag state, or Canary-version drift.
+5. Create sessions only after user activation when creation may trigger a model download.
+6. Use the `monitor` option during `create()` when the product needs download progress; do not assume progress events fire on every Canary build, only on the milestone documented in `references/compatibility.md`.
+7. Pass `taskType` on each `embed()` call, never on `create()`; the create-time options for this API do not accept `taskType`.
+8. Call `destroy()` when the session is no longer needed; the API does not currently document a per-call `AbortSignal` for `embed()`, so cancellation must be handled in product logic instead of assumed from the platform.
+
+**Step 4: Wire UX, task selection, and embedding-space versioning**
+1. Surface distinct states for missing APIs, insecure or non-desktop contexts, disabled EPP flags, downloading or unready models, ready sessions, in-flight embedding calls, and fallback behavior.
+2. Keep a non-AI fallback (server-side embeddings, keyword search, or a disabled feature state) for unsupported browsers, non-desktop platforms, or environments that do not meet current EPP requirements.
+3. Use `retrieval-document` when embedding a collection to index and `retrieval-query` when embedding a live user search; do not reuse the same `taskType` for both sides of a retrieval flow.
+4. Use `semantic-similarity` only for general text-similarity comparisons, not for retrieval ranking.
+5. Tag every stored vector with a local schema or model-version marker before persisting it in IndexedDB, OPFS, or another store; the API does not currently expose a model or embedding-space identifier, so the application is responsible for detecting stale vectors after a browser or model update.
+6. Never compare or mix `Float32Array` vectors that may have been produced by different underlying model versions; when versioning cannot be proven, prefer re-embedding over trusting a cached vector.
+7. Do not route translation, summarization, generation, or generic chat tasks through this API; switch to Translator, Writing Assistance APIs, Prompt API, or another approved capability when the task is not text embedding.
+8. Pre-chunk large documents before calling `embed()`; the API does not auto-chunk oversized input.
+
+**Step 5: Validate behavior**
+1. Execute `node scripts/find-semantic-embedder-targets.mjs .` to confirm that the intended app boundary and Semantic Embedder API markers still resolve to the edited integration surface.
+2. Verify secure-context checks, desktop-platform assumptions, `SemanticEmbedder` feature detection, and `availability()` behavior before debugging deeper runtime failures.
+3. Test at least one single-string `embed()` call and one batched `embed()` call with representative product text.
+4. Confirm similarity scoring behaves as expected using a known similar pair and a known dissimilar pair of inputs.
+5. Confirm that `destroy()` releases the session and that a destroyed session is not reused.
+6. Re-check `references/compatibility.md` before treating a failure as an application bug; this API is an actively-changing Early Preview Program feature and its shipped behavior can move between Canary milestones.
+7. Run the workspace build, typecheck, or tests after editing.
+
+## Error Handling
+* If `SemanticEmbedder` is missing, keep a non-AI fallback and confirm secure-context, desktop-platform, Canary-version, and EPP flag requirements before changing product logic.
+* If `availability()` resolves to anything other than `available`, treat the session as not ready; the developer-facing guide only confirms `available` and `unavailable` explicitly, so do not assume the full four-state enum used by sibling Built-in AI APIs is guaranteed for this feature without re-checking `references/compatibility.md`.
+* If `create()` fails outright with no download-progress events, confirm the browser build meets the minimum Canary milestone in `references/compatibility.md`; earlier builds can require the model to be fully downloaded before `create()` succeeds at all.
+* If a `taskType` passed to `create()` appears to have no effect, move it to the `embed()` call options; `taskType` is an `embed()`-time parameter only.
+* If embeddings compared across sessions produce nonsensical similarity scores, confirm both vectors came from the same embedding space (the same browser and model version) instead of assuming persisted vectors remain valid indefinitely.
+* If the feature must run in a worker, on a mobile platform, or on the server, stop and explain that the Semantic Embedder API is a desktop, window-only browser API.

--- a/skills/semantic-embedder-api/assets/semantic-embedder-session.template.ts
+++ b/skills/semantic-embedder-api/assets/semantic-embedder-session.template.ts
@@ -1,0 +1,123 @@
+export type SemanticEmbedderAvailability = "unavailable" | "available" | string;
+
+export type SemanticEmbedderTaskType =
+  | "semantic-similarity"
+  | "retrieval-query"
+  | "retrieval-document"
+  | "classification"
+  | "clustering";
+
+export type EmbeddingResult = {
+  values: Float32Array;
+};
+
+export type EmbedderResult = {
+  embeddings: EmbeddingResult[];
+};
+
+export type DownloadProgress = {
+  loaded: number;
+  total: number | null;
+  fraction: number | null;
+};
+
+export type SemanticEmbedderCreateOptions = {
+  onDownloadProgress?: (progress: DownloadProgress) => void;
+};
+
+export type SemanticEmbedderEmbedOptions = {
+  taskType?: SemanticEmbedderTaskType;
+};
+
+export interface SemanticEmbedderSession {
+  embed(input: string | string[], options?: SemanticEmbedderEmbedOptions): Promise<EmbedderResult>;
+  destroy(): void;
+}
+
+declare const SemanticEmbedder: {
+  availability(): Promise<SemanticEmbedderAvailability>;
+  create(options?: { monitor?: (monitor: EventTarget) => void }): Promise<SemanticEmbedderSession>;
+};
+
+function attachMonitor(
+  onDownloadProgress: SemanticEmbedderCreateOptions["onDownloadProgress"],
+): ((monitor: EventTarget) => void) | undefined {
+  if (!onDownloadProgress) {
+    return undefined;
+  }
+
+  return monitor => {
+    monitor.addEventListener("downloadprogress", event => {
+      const progressEvent = event as Event & { loaded: number; total?: number };
+      const total = typeof progressEvent.total === "number" ? progressEvent.total : null;
+      const loaded = typeof progressEvent.loaded === "number" ? progressEvent.loaded : 0;
+
+      onDownloadProgress({
+        loaded,
+        total,
+        fraction: total && total > 0 ? loaded / total : loaded <= 1 ? loaded : null,
+      });
+    });
+  };
+}
+
+export function isSemanticEmbedderSupported(): boolean {
+  if (typeof self === "undefined") {
+    return false;
+  }
+
+  return Boolean(globalThis.isSecureContext && "SemanticEmbedder" in self);
+}
+
+export async function getSemanticEmbedderAvailability(): Promise<SemanticEmbedderAvailability> {
+  if (!isSemanticEmbedderSupported()) {
+    return "unavailable";
+  }
+
+  return SemanticEmbedder.availability();
+}
+
+export async function createSemanticEmbedderSession(
+  options: SemanticEmbedderCreateOptions = {},
+): Promise<SemanticEmbedderSession | null> {
+  const availability = await getSemanticEmbedderAvailability();
+  if (availability === "unavailable") {
+    return null;
+  }
+
+  return SemanticEmbedder.create({
+    monitor: attachMonitor(options.onDownloadProgress),
+  });
+}
+
+export function cosineSimilarity(vecA: Float32Array, vecB: Float32Array): number {
+  if (!vecA || !vecB || vecA.length !== vecB.length) {
+    return 0;
+  }
+
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < vecA.length; i++) {
+    dotProduct += vecA[i] * vecB[i];
+    normA += vecA[i] * vecA[i];
+    normB += vecB[i] * vecB[i];
+  }
+
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+
+  return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+// The API does not expose a model/embedding-space identifier on results, so
+// callers must version their own stored vectors to detect staleness after a
+// browser or model update.
+export function tagEmbeddingSchemaVersion<T extends Record<string, unknown>>(
+  record: T,
+  schemaVersion: string,
+): T & { embeddingSchemaVersion: string } {
+  return { ...record, embeddingSchemaVersion: schemaVersion };
+}

--- a/skills/semantic-embedder-api/references/compatibility.md
+++ b/skills/semantic-embedder-api/references/compatibility.md
@@ -1,0 +1,46 @@
+# Compatibility
+
+Semantic Embedder API support is Early Preview Program (EPP)-only and rollout-sensitive. Treat browser channel, flag state, and platform constraints as explicit product dependencies, and re-check this file more often than for other Built-in AI APIs because the feature is actively iterating.
+
+## Baseline support notes
+
+* The API is defined by an early-stage design explainer (`explainers-by-googlers/semantic-embedder-api`) that explicitly states it "has not been approved to ship in Chrome." There is no standards-track specification yet.
+* The concrete implementation available to Early Preview Program testers can differ from, and lag behind, the design explainer's proposed surface (for example, the explainer's proposed `statistics` and `metadata` result fields are not present in the shipped developer guide).
+* The API targets desktop only: Linux, macOS, and Windows. It is not available on Chrome for Android, iOS, or any mobile platform.
+* The backing model is based on `embeddinggemma-300m` (a LiteRT Community build of Google's `embeddinggemma-300m`).
+
+## Chrome notes
+
+* Requires Chrome Canary version `153.0.7979.0` or later.
+* Requires manually enabling `chrome://flags/#semantic-embedder-api`; this is not enabled by default and is not tied to a general Chrome release milestone.
+* Only visible and functional for participants of the Early Preview Program; general Chrome users on stable, beta, or dev channels should not be expected to have this feature.
+* Model download progress via the `monitor` option and `downloadprogress` events is only supported starting with Chrome `153.0.7979.0`. Earlier EPP builds did not support progress events at all, and `create()` would fail outright unless the model happened to already be fully downloaded.
+* Recommend checking support with `'SemanticEmbedder' in self` before calling `availability()`.
+* The EPP developer guide's `downloadprogress` sample treats `event.loaded` as a `0-1` fraction (`e.loaded * 100` for a percentage), matching the convention Chrome uses for other Built-in AI APIs in this repository (Language Detector, Translator).
+
+## Microsoft Edge and other browsers
+
+* No Edge, Firefox, or Safari support has been documented for this API. Treat it as a single-vendor, single-channel EPP feature until further notice.
+
+## Secure context and frame rules
+
+* Secure context is required.
+* The design explainer proposes gating access behind an embedding-scoped permissions policy, restricted to top-level frames and same-origin iframes by default, with cross-origin frames requiring explicit delegation. This has not been confirmed against the shipped EPP build; do not hardcode a specific `allow="..."` token without verifying it empirically against the current Canary build.
+
+## Creation, download, and versioning behavior
+
+* `availability()` and `create()` behavior is documented in the EPP guide primarily through an `"available"` / not-`"available"` check; do not assume the full `unavailable` / `downloadable` / `downloading` / `available` enum used by sibling APIs is guaranteed here without empirical verification.
+* The first trial on a user profile can require a multi-second model download; only surface this without a `monitor` callback if the product can tolerate an unexplained delay.
+* Embeddings are only comparable within the same embedding space (the same model version). The API does not expose a version or embedding-space identifier on results, so treat any persisted vector as potentially stale after a browser update and re-embed when in doubt.
+* The changelog for the developer guide shows the surface changing multiple times within the same month (clarifying that `taskType` belongs on `embed()`, not `create()`; adding download-progress support at a specific milestone), which is strong evidence this API is still in active flux.
+
+## TypeScript and typings
+
+* Browser DOM typings for this API are not guaranteed in any TypeScript version and are not part of `@types/dom-chromium-ai` at the time of writing.
+* Add narrow, feature-specific typings scoped to the surface actually used (`availability()`, `create()`, `embed()`, `destroy()`) instead of widening the global namespace with speculative fields from the design explainer that are not yet shipped.
+
+## Product guidance
+
+* Do not ship this API as the only path for a production feature; it is EPP-gated behind a manual flag and a specific Canary build, so the addressable user population is effectively zero outside of internal testing and EPP participants.
+* Keep a visible, fully functional fallback (server-side embeddings, keyword search, or a disabled feature state) for every browser and platform this API does not cover.
+* Re-check this file against the current EPP developer guide and the `explainers-by-googlers/semantic-embedder-api` repository before treating any behavior here as stable, since both sources are being revised frequently.

--- a/skills/semantic-embedder-api/references/examples.md
+++ b/skills/semantic-embedder-api/references/examples.md
@@ -1,0 +1,145 @@
+# Examples
+
+Use these patterns as shape references. Adapt them to the host framework and state model instead of copying them blindly.
+
+## Support detection
+
+```ts
+function detectSemanticEmbedderSupport(): { supported: boolean; reason: string | null } {
+  const runtimeScope = globalThis as typeof globalThis & {
+    isSecureContext?: boolean;
+    SemanticEmbedder?: unknown;
+  };
+
+  if (!runtimeScope.isSecureContext) {
+    return { supported: false, reason: "Semantic Embedder requires HTTPS or localhost." };
+  }
+
+  if (!runtimeScope.SemanticEmbedder) {
+    return {
+      supported: false,
+      reason: "SemanticEmbedder is unavailable. Confirm Chrome Canary and the semantic-embedder-api flag.",
+    };
+  }
+
+  return { supported: true, reason: null };
+}
+
+const support = detectSemanticEmbedderSupport();
+if (!support.supported) {
+  console.warn(support.reason);
+}
+```
+
+## Availability and monitored session creation
+
+```ts
+const availability = await SemanticEmbedder.availability();
+
+if (availability !== "available") {
+  console.warn(`Semantic Embedder is not immediately ready: ${availability}`);
+}
+
+const semanticEmbedder = await SemanticEmbedder.create({
+  monitor(monitor) {
+    monitor.addEventListener("downloadprogress", event => {
+      const progressEvent = event as Event & { loaded: number; total?: number };
+      console.log(`Downloaded ${progressEvent.loaded * 100}%`);
+    });
+  },
+});
+```
+
+## Single-string similarity comparison
+
+```ts
+function cosineSimilarity(vecA: Float32Array, vecB: Float32Array): number {
+  if (!vecA || !vecB || vecA.length !== vecB.length) {
+    return 0;
+  }
+
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < vecA.length; i++) {
+    dotProduct += vecA[i] * vecB[i];
+    normA += vecA[i] * vecA[i];
+    normB += vecB[i] * vecB[i];
+  }
+
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+
+  return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+const resultA = await semanticEmbedder.embed("The quick brown fox jumps over the lazy dog.", {
+  taskType: "semantic-similarity",
+});
+const resultB = await semanticEmbedder.embed("A fast, dark-colored fox leaps over a resting hound.", {
+  taskType: "semantic-similarity",
+});
+
+const similarity = cosineSimilarity(resultA.embeddings[0].values, resultB.embeddings[0].values);
+console.log(`Similarity score: ${similarity}`);
+```
+
+## Batched retrieval indexing
+
+```ts
+const passages = [
+  "Built-in AI APIs use on-device models.",
+  "Embeddings are high-dimensional vectors representing semantic meaning.",
+];
+
+const documentBatch = await semanticEmbedder.embed(passages, {
+  taskType: "retrieval-document",
+});
+
+for (let i = 0; i < documentBatch.embeddings.length; i++) {
+  await myLocalVectorDB.insert({
+    text: passages[i],
+    embedding: documentBatch.embeddings[i].values,
+    // Track the schema/model context locally; the result object does not
+    // expose an embedding-space or model-version identifier.
+    embeddingSchemaVersion: CURRENT_EMBEDDING_SCHEMA_VERSION,
+  });
+}
+```
+
+## Query-time retrieval embedding
+
+```ts
+const queryResult = await semanticEmbedder.embed(userSearchText, {
+  taskType: "retrieval-query",
+});
+
+const queryVector = queryResult.embeddings[0].values;
+const matches = await myLocalVectorDB.searchByVector(queryVector);
+```
+
+## Cleanup
+
+```ts
+let session: SemanticEmbedderSession | null = null;
+
+try {
+  session = await SemanticEmbedder.create();
+  const result = await session.embed(userText, { taskType: "semantic-similarity" });
+  render(result);
+} finally {
+  session?.destroy();
+}
+```
+
+## Decision shortcuts
+
+Use `retrieval-document` when embedding the side of a flow that gets indexed, and `retrieval-query` when embedding the side that searches it. Never mix the two for the same flow.
+
+Use `semantic-similarity` only for direct text-to-text comparisons, not for retrieval ranking.
+
+Do not omit `taskType` in production code paths; an unset `taskType` produces a raw, non-task-optimized embedding.
+
+Version-tag every persisted vector before storage; there is no API-native way to detect that the underlying model changed between sessions.

--- a/skills/semantic-embedder-api/references/semantic-embedder-reference.md
+++ b/skills/semantic-embedder-api/references/semantic-embedder-reference.md
@@ -1,0 +1,104 @@
+# Semantic Embedder API Reference
+
+Use this file for core API shape and rules before writing or reviewing browser integrations.
+
+## Status
+
+`SemanticEmbedder` is an Early Preview Program (EPP) API from the Chrome Built-in AI team. It has not been approved to ship and is not part of a standards-track specification yet. Treat every detail here as subject to change between Canary milestones; re-check `references/compatibility.md` before relying on specific behavior.
+
+## API surface
+
+`SemanticEmbedder` is a secure-context `Window` API, available on desktop only.
+
+Core members:
+
+* `SemanticEmbedder.availability(options?)`
+* `SemanticEmbedder.create(options?)`
+* `session.embed(input, options?)`
+* `session.destroy()`
+
+## Create options
+
+`create()` accepts:
+
+* `monitor?: (monitor: EventTarget) => void`
+
+`create()` does not accept `taskType`. Passing it there has no documented effect; `taskType` belongs on `embed()` calls only.
+
+## Availability states
+
+The developer guide's sample code checks `availability()` against `"available"` and treats every other value as not ready:
+
+```js
+if (!SemanticEmbedder || (await SemanticEmbedder.availability()) !== "available") {
+  console.error("Semantic Embedder API is not available on this device.");
+}
+```
+
+Sibling Built-in AI APIs (Language Detector, Translator, Proofreader, Writing Assistance) use a four-state `unavailable` / `downloadable` / `downloading` / `available` enum. The Semantic Embedder developer guide has not explicitly documented all four states for this API, so treat any value other than `"available"` as "not ready yet" rather than branching on a specific state name.
+
+## `embed()` input and output
+
+`embed()` accepts a single string or an array of strings (batch input):
+
+```js
+const single = await session.embed("some text");
+const batch = await session.embed(["passage one", "passage two"]);
+```
+
+`embed()` returns an `EmbedderResult`:
+
+```js
+{
+  embeddings: [
+    { values: Float32Array(256) } // dimension is model-defined
+    // one entry per input string, in the same order
+  ]
+}
+```
+
+Rules:
+
+* Batch results correspond 1:1, in order, with the input array.
+* The API does not automatically chunk large text inputs; pre-chunk documents before calling `embed()`.
+* The API does not currently expose token-count, truncation, or model/version metadata on the result object. Design proposals for a `statistics` field (per-embedding token counts) and a `metadata` field (embedding-space or model identifier) exist in the API explainer but are not part of the shipped developer-guide surface; do not assume they exist without re-checking `references/compatibility.md`.
+
+## `taskType` option
+
+`embed(input, { taskType })` accepts an optional `taskType` hint:
+
+| `taskType` value | Use case |
+| --- | --- |
+| `"semantic-similarity"` | Optimized for assessing text similarity. Not intended for retrieval. |
+| `"retrieval-query"` | Optimized for embedding a user's real-time search query. |
+| `"retrieval-document"` | Optimized for embedding a document collection to index in a vector database. |
+| `"classification"` | Optimized for classifying text against preset labels (sentiment analysis, spam detection). |
+| `"clustering"` | Optimized for clustering text by similarity (document organization, market research, anomaly detection). |
+
+Rules:
+
+* `taskType` is optional. If it is not specified, the API computes the embedding for the raw string input as-is; it does not silently choose a default optimized task.
+* Always pick a `taskType` deliberately for production similarity or retrieval code; relying on the unset default means comparing unoptimized, non-task-tuned vectors.
+* Use `retrieval-document` for the indexed side of a retrieval flow and `retrieval-query` for the query side; do not use the same `taskType` for both.
+* Task types are a hint the browser can ignore if the underlying model does not support them; do not treat them as a hard contract on output shape or dimensionality.
+
+## Embedding-space and comparability
+
+* Embeddings can only be compared when they originate from the same embedding space, meaning the same model version produced them.
+* The API does not currently expose an embedding-space or model-version identifier on the result. Applications must externally track when their stored vectors might have been produced by a different model build (for example, after a browser update) and re-embed rather than trust a cached vector across an unproven version boundary.
+* Do not compare vectors produced by different sessions, browsers, or platforms unless the product has an explicit way to confirm they share the same embedding space.
+
+## Lifecycle and cleanup
+
+* `create()` initializes a session; the resulting session exposes `embed()` and `destroy()`.
+* Call `destroy()` proactively once embeddings have been extracted, especially after a large batch call, to release model resources.
+* The developer guide's `embed()` and `create()` signatures do not document a per-call `AbortSignal`; do not add cancellation logic that assumes one exists without re-verifying against `references/compatibility.md`.
+
+## Permissions policy and context limits
+
+* The API's design explainer describes access as gated by an embedding-scoped permissions policy, restricted to top-level frames and same-origin iframes by default, with third-party contexts requiring explicit delegation. This has not been confirmed as implemented in the shipped EPP build; verify current iframe behavior empirically before depending on cross-origin delegation syntax.
+* The API is scoped to desktop platforms (Linux, macOS, Windows); it is not available on Chrome for Android, iOS, or other mobile platforms.
+
+## Error shapes
+
+Neither the developer guide nor the public design explainer enumerates specific exception names (such as `NotAllowedError` or `OperationError`) for this API yet. Implement generic `try`/`catch` around `create()` and `embed()`, log `error.name` and `error.message` for diagnosis, and treat unrecognized failures as environment or EPP-build issues rather than permanent unsupported states.

--- a/skills/semantic-embedder-api/references/troubleshooting.md
+++ b/skills/semantic-embedder-api/references/troubleshooting.md
@@ -1,0 +1,98 @@
+# Troubleshooting
+
+## Missing `SemanticEmbedder`
+
+Symptoms:
+
+* `ReferenceError: SemanticEmbedder is not defined`
+* feature detection fails
+
+Checks:
+
+1. Confirm a secure context.
+2. Confirm the browser is Chrome Canary at or above the version documented in `references/compatibility.md`.
+3. Confirm `chrome://flags/#semantic-embedder-api` is manually enabled; this flag is not on by default and is not enabled by joining the Early Preview Program alone.
+4. Confirm the code is running in a window, not in a worker or server runtime.
+5. Confirm the platform is desktop (Linux, macOS, Windows); the API is not available on mobile.
+
+## `availability()` does not resolve to `available`
+
+Checks:
+
+1. Retry after the model has had time to download; the first trial on a profile can take several seconds.
+2. Confirm the flag and Canary-version requirements from `references/compatibility.md` are met.
+3. Do not branch on a specific non-`available` state name; the developer guide only confirms `"available"` explicitly, so treat every other value as "not ready" rather than assuming a specific downloadable/downloading semantics.
+4. Keep the fallback path instead of forcing `create()`.
+
+## `create()` fails with no download-progress events
+
+Likely cause:
+
+* the Canary build predates the milestone where `monitor`/`downloadprogress` support was added
+
+Checks:
+
+1. Confirm the build meets the minimum Canary version in `references/compatibility.md`.
+2. On earlier builds, `create()` can fail outright unless the model is already fully downloaded; there is no progress signal to wait on in that case.
+3. Retry `create()` after a delay or prompt the user to update Chrome Canary.
+
+## `taskType` seems to have no effect
+
+Likely cause:
+
+* `taskType` was passed to `create()` instead of `embed()`
+
+Remediation:
+
+1. Move the `taskType` option to the `embed()` call.
+2. Confirm the value is one of `"semantic-similarity"`, `"retrieval-query"`, `"retrieval-document"`, `"classification"`, or `"clustering"`.
+3. Remember that `taskType` is a hint the underlying model can ignore; if quality does not visibly change, this can be expected model behavior rather than an integration bug.
+
+## Similarity or retrieval scores look wrong
+
+Likely causes:
+
+* `taskType` was omitted, producing an unoptimized raw embedding
+* the query side and the document side used mismatched `taskType` values
+* the compared vectors came from different embedding spaces (different model or browser versions)
+* the input text was truncated by an upstream chunking step in a way that changed its meaning
+
+Remediation:
+
+1. Set an explicit `taskType` matched to the use case instead of relying on the unset default.
+2. Use `retrieval-document` for indexed content and `retrieval-query` for the search query; do not mix them.
+3. Re-embed instead of trusting old persisted vectors if there is any chance the model changed since they were stored.
+4. Review chunking logic for documents that exceed the model's input limit.
+
+## Large input fails or is silently truncated
+
+Likely cause:
+
+* the input exceeds the model's token limit and the API does not auto-chunk
+
+Remediation:
+
+1. Pre-chunk large documents before calling `embed()`.
+2. Treat chunk-size limits as approximate and re-verify against current Chrome documentation, since the exact limit is sourced from the design explainer rather than the shipped developer guide.
+
+## Worker or server integration fails
+
+Likely cause:
+
+* the API is a `Window`-scoped, desktop-only browser API
+
+Remediation:
+
+1. Move the embedding boundary to a window-owned module or UI controller.
+2. Stop and explain the platform mismatch if the feature contract requires worker-only, server-side, or mobile execution.
+
+## Unrecognized exception during `create()` or `embed()`
+
+Likely cause:
+
+* neither the developer guide nor the design explainer enumerates a stable exception list for this API yet
+
+Remediation:
+
+1. Log `error.name` and `error.message` for diagnosis instead of matching against a hardcoded exception list.
+2. Treat unrecognized failures as environment or EPP-build issues, and confirm flag, Canary-version, and platform requirements before assuming an application bug.

--- a/skills/semantic-embedder-api/scripts/find-semantic-embedder-targets.mjs
+++ b/skills/semantic-embedder-api/scripts/find-semantic-embedder-targets.mjs
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const IGNORED_DIRS = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+  ".next",
+  ".nuxt",
+  "out",
+  "target",
+  "venv",
+  ".venv",
+  "__pycache__",
+]);
+
+const SEMANTIC_EMBEDDER_MARKERS = [
+  "SemanticEmbedder",
+  "SemanticEmbedder.create(",
+  "SemanticEmbedder.availability(",
+  ".embed(",
+  "taskType",
+  "embeddings[0].values",
+  'allow="semantic-embedder"',
+];
+
+const PRIORITY_FILES = new Map([
+  ["package.json", 100],
+  ["index.html", 90],
+  ["vite.config.ts", 80],
+  ["vite.config.js", 80],
+  ["src/main.ts", 75],
+  ["src/main.tsx", 75],
+  ["src/main.js", 75],
+  ["src/main.jsx", 75],
+  ["src/app.tsx", 70],
+  ["src/app.ts", 70],
+  ["src/app.jsx", 70],
+  ["src/app.js", 70],
+]);
+
+const SCAN_EXTENSIONS = new Set([".html", ".js", ".jsx", ".ts", ".tsx", ".vue", ".svelte"]);
+
+function toPosixRelative(root, targetPath) {
+  return path.relative(root, targetPath).split(path.sep).join("/");
+}
+
+function readDirEntries(directoryPath) {
+  try {
+    return fs.readdirSync(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Warning: Skipping unreadable directory ${directoryPath}: ${message}`);
+    return [];
+  }
+}
+
+function walkFiles(root) {
+  const files = [];
+  const pending = [root];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    const entries = readDirEntries(current);
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRS.has(entry.name)) {
+          pending.push(path.join(current, entry.name));
+        }
+        continue;
+      }
+
+      if (entry.isFile()) {
+        files.push(path.join(current, entry.name));
+      }
+    }
+  }
+
+  return files;
+}
+
+function scoreFile(root, filePath) {
+  const relative = toPosixRelative(root, filePath);
+  if (PRIORITY_FILES.has(relative)) {
+    return PRIORITY_FILES.get(relative);
+  }
+
+  if (SCAN_EXTENSIONS.has(path.extname(filePath))) {
+    return 40;
+  }
+
+  return 0;
+}
+
+function findSemanticEmbedderMarkers(filePath) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return [];
+  }
+
+  return SEMANTIC_EMBEDDER_MARKERS.filter(marker => content.includes(marker));
+}
+
+function main() {
+  const rootArg = process.argv[2] ?? ".";
+  const root = path.resolve(rootArg);
+
+  if (!fs.existsSync(root)) {
+    console.error(`Path does not exist: ${root}`);
+    process.exit(1);
+  }
+
+  const scoredFiles = [];
+  const semanticEmbedderHits = [];
+
+  for (const filePath of walkFiles(root)) {
+    const score = scoreFile(root, filePath);
+    if (score > 0) {
+      scoredFiles.push([score, toPosixRelative(root, filePath)]);
+    }
+
+    if (SCAN_EXTENSIONS.has(path.extname(filePath))) {
+      const markers = findSemanticEmbedderMarkers(filePath);
+      if (markers.length > 0) {
+        semanticEmbedderHits.push([toPosixRelative(root, filePath), markers]);
+      }
+    }
+  }
+
+  scoredFiles.sort((left, right) => right[0] - left[0] || left[1].localeCompare(right[1]));
+  semanticEmbedderHits.sort((left, right) => left[0].localeCompare(right[0]));
+
+  console.log("Frontend targets:");
+  if (scoredFiles.length > 0) {
+    for (const [, relative] of scoredFiles.slice(0, 20)) {
+      console.log(`- ${relative}`);
+    }
+  } else {
+    console.log("- No likely frontend files found");
+  }
+
+  console.log("\nSemantic Embedder API indicators:");
+  if (semanticEmbedderHits.length > 0) {
+    for (const [relative, markers] of semanticEmbedderHits) {
+      console.log(`- ${relative}: ${markers.join(", ")}`);
+    }
+  } else {
+    console.log("- No Semantic Embedder API markers found");
+  }
+}
+
+main();

--- a/skills/semantic-embedder-api/scripts/find-semantic-embedder-targets.mjs
+++ b/skills/semantic-embedder-api/scripts/find-semantic-embedder-targets.mjs
@@ -20,10 +20,10 @@ const SEMANTIC_EMBEDDER_MARKERS = [
   "SemanticEmbedder",
   "SemanticEmbedder.create(",
   "SemanticEmbedder.availability(",
-  ".embed(",
   "taskType",
+  "retrieval-document",
+  "retrieval-query",
   "embeddings[0].values",
-  'allow="semantic-embedder"',
 ];
 
 const PRIORITY_FILES = new Map([


### PR DESCRIPTION
Adds `skills/semantic-embedder-api`, covering the Chrome Early Preview Program Semantic Embedder API (`SemanticEmbedder.availability()` → `create()` → `embed()` → `destroy()`).

Follows the repo's established skill structure (`SKILL.md` + `references/` + `assets/` + `scripts/`), modeled on `language-detector-api` and `translator-api`.

Key things this skill teaches an agent that are specific/easy to get wrong for this API:
- `taskType` belongs on `embed()`, not `create()` (the vendor doc itself was corrected on this).
- Omitting `taskType` doesn't get you a sane default — it silently returns an unoptimized raw-string embedding.
- Embeddings are only comparable within the same embedding space (same model version), and the API exposes no version/space identifier on results, so persisted vectors need app-side versioning.
- This is EPP-only: requires Chrome Canary ≥153.0.7979.0, a manual `chrome://flags/#semantic-embedder-api` flag, and desktop-only platforms — not a general-availability feature, so `compatibility.md` is written to be re-checked often.

**Changes:**
- `skills/semantic-embedder-api/SKILL.md` — procedures + error handling
- `references/semantic-embedder-reference.md`, `examples.md`, `compatibility.md`, `troubleshooting.md`
- `assets/semantic-embedder-session.template.ts` — typed session wrapper
- `scripts/find-semantic-embedder-targets.mjs` — workspace scanner
- `README.md` — new skill section, TOC entry, and "Common Workflows" scanner entry

**Sources used:** the Chrome EPP developer guide (Semantic Embedder API, last updated 2026-07-31) and the public design explainer at `explainers-by-googlers/semantic-embedder-api`, cross-checked against each other since the explainer is ahead of what's actually shipped.

Validated `name`/`description` with `.github/skills/skill-creator/scripts/validate-metadata.py` (passes) and checked the skill against `.github/skills/skill-creator/references/checklist.md`.