### PR TITLE
Update WebMCP skill for Chrome 153 cancellation

### DIFF
--- a/skills/webmcp/SKILL.md
+++ b/skills/webmcp/SKILL.md
@@ -4,7 +4,7 @@ description: Implements and debugs browser WebMCP integrations in JavaScript or 
 license: MIT
 metadata:
   author: webmaxru
-  version: "1.5"
+  version: "1.6"
 ---
 
 # WebMCP
@@ -26,7 +26,7 @@ metadata:
 4. Read `references/troubleshooting.md` when registration, schema serialization, or agent-driven form execution fails.
 5. Verify that the integration runs in a secure window browsing context.
 6. If the feature must run on the server, in a worker, or headlessly without a visible browsing context, stop and explain the platform limitation.
-7. Choose the imperative API when the tool wraps existing JavaScript logic, requires dynamic registration, or needs `ModelContextClient.requestUserInteraction()`.
+7. Choose the imperative API when the tool wraps existing JavaScript logic, requires dynamic registration, or must handle execution cancellation.
 8. Choose the declarative API when the user flow already maps cleanly to a form submission and the page can keep the human-visible form in sync with agent activity.
 9. Keep tool names, descriptions, and parameters explicit and positive, and prefer atomic tools over overlapping variants.
 
@@ -38,14 +38,15 @@ metadata:
 5. Set `annotations.untrustedContentHint` to `true` when the tool's output may contain data from untrusted sources.
 6. Validate business rules inside the tool implementation even when the schema is strict, and return descriptive errors that help the agent retry with corrected input.
 7. Return tool results only after the UI and application state reflect the tool's effect.
-8. If tool availability depends on route, selection, or page state, register tools only while they are valid and unregister stale tools by aborting the `AbortController` whose signal was passed to `registerTool()`; during the Chrome 148 transition window, also call `modelContext.unregisterTool?.()` with optional chaining before aborting.
-9. For declarative tools, annotate the target `<form>` with `toolname` and `tooldescription`, and let form controls define the parameter surface.
-10. Use labels or `toolparamdescription` to produce clear parameter descriptions for declarative fields.
-11. Use `toolautosubmit` only when the page should submit automatically after the agent populates the form.
+8. On Chrome 153+, accept the always-present `{ signal }` as the second `execute` argument and pass it to cancellable work such as `fetch()`. Treat this execution signal separately from the registration signal.
+9. If tool availability depends on route, selection, or page state, register tools only while they are valid and unregister stale tools by aborting the `AbortController` whose signal was passed to `registerTool()`; during the Chrome 148 transition window, also call `modelContext.unregisterTool?.()` with optional chaining before aborting.
+10. For declarative tools, annotate the target `<form>` with `toolname` and `tooldescription`, and let form controls define the parameter surface.
+11. Use labels or `toolparamdescription` to produce clear parameter descriptions for declarative fields.
+12. Use `toolautosubmit` only when the page should submit automatically after the agent populates the form.
 
 **Step 4: Wire agent-driven UX safely**
 1. Preserve the normal human interaction path even when the page supports agent invocation.
-2. When an imperative tool needs explicit confirmation or a user-facing step, call `client.requestUserInteraction()` instead of bypassing the UI.
+2. When a tool needs explicit confirmation or a user-facing step, route it through the application's visible UI and existing authorization checks; the current `execute(input, { signal })` contract does not provide a client callback.
 3. When customizing declarative submit handling, call `preventDefault()` before `respondWith()` and return structured validation errors for agent-invoked submits.
 4. Use preview-only events such as `toolactivated`, `toolcancel`, `agentInvoked`, and WebMCP form pseudo-classes only behind compatibility-aware UI logic.
 5. Keep destructive or sensitive actions gated behind visible user confirmation, even if the agent can prepare the input.
@@ -56,10 +57,11 @@ metadata:
 2. Test invalid or incomplete inputs to confirm the tool returns corrective errors instead of silently failing.
 3. For declarative tools, verify generated parameter descriptions, required fields, submit behavior, and any custom `respondWith()` handling.
 4. If the target environment is the current Chrome preview, confirm the required version and flag state from `references/compatibility.md` before treating runtime failures as application bugs.
-5. Use the Model Context Tool Inspector or equivalent preview tooling only as a validation aid, not as a runtime dependency.
-6. Validate deterministic execution first by inspecting the registered tool set and manually invoking the tool with representative arguments when preview tooling is available.
-7. After deterministic execution is correct, validate natural-language routing so descriptions and parameter shapes guide the agent toward the correct tool.
-8. Run the workspace build, typecheck, or tests after editing.
+5. Test execution cancellation by aborting the signal passed to `executeTool()` and verify that long-running work stops without relying on tool unregistration.
+6. Use the Model Context Tool Inspector or equivalent preview tooling only as a validation aid, not as a runtime dependency.
+7. Validate deterministic execution first by inspecting the registered tool set and manually invoking the tool with representative arguments when preview tooling is available.
+8. After deterministic execution is correct, validate natural-language routing so descriptions and parameter shapes guide the agent toward the correct tool.
+9. Run the workspace build, typecheck, or tests after editing.
 
 ## Error Handling
 * If both `document.modelContext` and `navigator.modelContext` are missing, confirm the code is running in a secure browser window context and then check the preview requirements in `references/compatibility.md`.

--- a/skills/webmcp/assets/model-context-registry.template.ts
+++ b/skills/webmcp/assets/model-context-registry.template.ts
@@ -2,8 +2,8 @@ type JsonSchema = Record<string, unknown>;
 
 type ToolResult = unknown;
 
-type ToolContextClient = {
-  requestUserInteraction(callback: () => Promise<unknown>): Promise<unknown>;
+type ToolExecuteOptions = {
+  signal: AbortSignal;
 };
 
 type ToolDefinition = {
@@ -15,10 +15,15 @@ type ToolDefinition = {
     readOnlyHint?: boolean;
     untrustedContentHint?: boolean;
   };
-  execute(input: Record<string, unknown>, client: ToolContextClient): Promise<ToolResult> | ToolResult;
+  execute(
+    input: Record<string, unknown>,
+    options: ToolExecuteOptions,
+  ): Promise<ToolResult> | ToolResult;
 };
 
-type ModelContext = NonNullable<Document["modelContext"]> | NonNullable<Navigator["modelContext"]>;
+type ModelContext =
+  | NonNullable<Document["modelContext"]>
+  | NonNullable<Navigator["modelContext"]>;
 
 function assertModelContext(): ModelContext {
   // Chrome 150+ exposes `document.modelContext`; older 146-149 previews used
@@ -42,17 +47,9 @@ export function registerWebMcpTools(tools: ToolDefinition[]) {
 
   // Registration is asynchronous on Chrome 151+: `registerTool()` returns a
   // Promise that resolves once the tool is visible to getTools() across the
-  // frame tree. Register the tools concurrently with Promise.all so the total
-  // wait is bounded by the slowest registration instead of the sum of all of
-  // them. Each tool keeps its own try/catch so the registrations stay
-  // independent — one failing tool never blocks the others (a bare Promise.all
-  // would otherwise reject and abandon the rest on the first failure). `await`
-  // stays backward compatible with older builds that returned void
-  // synchronously, and the try/catch handles both synchronous throws (older
-  // builds, locally-known failures) and Promise rejections (Chrome 151+
-  // asynchronous failures). `dispose()` stays synchronous so it can be used
-  // directly as framework effect cleanup while registration is still settling;
-  // await `ready` when you need registration to be complete.
+  // frame tree. Each tool keeps its own try/catch so one failure does not block
+  // independent registrations. Tool callbacks receive a separate execution
+  // signal on Chrome 153+; aborting this controller only controls registration.
   const ready = Promise.all(
     tools.map(async (tool) => {
       try {
@@ -79,11 +76,4 @@ export function registerWebMcpTools(tools: ToolDefinition[]) {
       controller.abort();
     },
   };
-}
-
-export async function requestConfirmedAction(
-  client: ToolContextClient,
-  callback: () => Promise<ToolResult>,
-) {
-  return client.requestUserInteraction(async () => callback());
 }

--- a/skills/webmcp/references/compatibility.md
+++ b/skills/webmcp/references/compatibility.md
@@ -16,7 +16,9 @@ Use this file when setup, browser support, or preview-only behaviors affect impl
 5. WebMCP is still an evolving Community Group specification rather than a standards-track recommendation.
 6. Starting in Chrome `148.0.7757.0`, `registerTool()` accepts an optional `{ signal: AbortSignal }` second argument and `unregisterTool()` is removed; use `AbortController` to manage tool lifetime on Chrome `148` and later.
 7. Starting in Chrome `150.0.7861.0`, the `modelContext` getter moved from `Navigator` to `Document`. `navigator.modelContext` is deprecated and will be removed in a future Chrome release. Resolve the context with `const modelContext = document.modelContext || navigator.modelContext;` so the same code keeps working on Chrome 146–149 and on Chrome 150+. See WebML CG [issue 173](https://github.com/webmachinelearning/webmcp/issues/173), spec [PR #184](https://github.com/webmachinelearning/webmcp/pull/184), and the demo migration in [GoogleChromeLabs/webmcp-tools PR #189](https://github.com/GoogleChromeLabs/webmcp-tools/pull/189/changes).
-8. Starting in Chrome `151.0.7922.0`, `registerTool()` returns a `Promise<void>` instead of `void`, resolving once the tool is available to `getTools()` across the frame tree. Await the call inside a `try`/`catch`; `await` keeps working on older builds that registered synchronously, so the pattern is backward compatible. See WebML CG [issue 175](https://github.com/webmachinelearning/webmcp/issues/175) and the demo migration in [GoogleChromeLabs/webmcp-tools PR #228](https://github.com/GoogleChromeLabs/webmcp-tools/pull/228).
+8. Starting in Chrome `151.0.7922.0`, `registerTool()` returns a `Promise<void>` instead of `void`, resolving once the tool is available to `getTools()` callers across the frame tree.
+9. Starting in Chrome `153.0.8009.0`, every imperative `execute` callback receives `{ signal }` as its second argument. Aborting the caller's execution signal propagates cancellation to this signal.
+10. Starting in Chrome `153.0.8009.0`, unregistering a tool no longer cancels its in-flight executions. Registration lifecycle cleanup and per-call execution cancellation are independent.
 
 ## Execution Context Limits
 
@@ -26,7 +28,7 @@ Use this file when setup, browser support, or preview-only behaviors affect impl
 
 ## Draft Versus Preview Differences
 
-1. The imperative API surface around `document.modelContext` (with the deprecated `navigator.modelContext` fallback), `registerTool()`, and `ModelContextClient.requestUserInteraction()` is more stable than the declarative surface. Note that `unregisterTool()` is removed in Chrome 148 in favour of the `AbortSignal` option, the `modelContext` getter moved from `Navigator` to `Document` in Chrome 150, and `registerTool()` returns a `Promise<void>` starting in Chrome 151 (await it inside a `try`/`catch`).
+1. The imperative API surface around `document.modelContext` (with the deprecated `navigator.modelContext` fallback), `registerTool()`, and execution cancellation is more stable than the declarative surface. Note that `unregisterTool()` is removed in Chrome 148 in favour of the `AbortSignal` option, the `modelContext` getter moved from `Navigator` to `Document` in Chrome 150, `registerTool()` returns a `Promise<void>` starting in Chrome 151, and `execute()` receives `{ signal }` starting in Chrome 153.
 2. Declarative WebMCP is not yet fully specified.
 3. Current preview implementations include additional declarative details for form attributes, submit interception, events, and CSS pseudo-classes.
 4. Keep imperative integrations aligned to the stable API shape, but treat declarative behaviors as compatibility-sensitive features until the spec stabilizes.
@@ -50,6 +52,8 @@ Use this file when setup, browser support, or preview-only behaviors affect impl
 6. Current preview tooling can manually execute tools with supplied arguments and surface runtime or schema errors.
 7. Some preview tooling uses extra browser testing surfaces such as `navigator.modelContextTesting`; treat those as diagnostic aids only.
 8. Natural-language testing through preview tooling is useful for refining descriptions and parameter shapes after deterministic execution already works.
+9. The polyfill updated in GoogleChromeLabs/webmcp-tools PR #321 handles caller-signal cancellation for local declarative forms and forwards options into same-origin nested contexts.
+10. That polyfill does not pass execution options to a locally registered imperative callback and does not forward the signal through its remote `postMessage` execution path. Validate Chrome 153 imperative and cross-origin cancellation in the native implementation rather than treating the polyfill as complete coverage.
 
 ## Platform Limitations
 

--- a/skills/webmcp/references/declarative-api.md
+++ b/skills/webmcp/references/declarative-api.md
@@ -39,6 +39,32 @@ Use this file when the page already has a form-centric user flow or when agent-d
 4. The preview applies `:tool-submit-active` to the submit control while the agent-driven form interaction is active.
 5. Treat these events and pseudo-classes as preview-only capabilities, not as the portable baseline.
 
+## Cancelling Declarative Execution
+
+1. When an in-page agent invokes a declarative tool with `document.modelContext.executeTool(tool, input, { signal })`, aborting the caller's signal cancels the pending form execution.
+2. Handle the rejected execution promise as cancellation. Current Chrome demo and polyfill code checks the caller signal's `aborted` state and stops the agent loop instead of returning the abort as a tool error.
+3. Expect the declarative form's active state to be cleaned up and a `toolcancel` event with `toolName` to be dispatched by the current Chrome-compatible implementation.
+4. Keep this caller-driven execution signal separate from form reset or tool-registration lifecycle changes, which can also end a declarative invocation.
+
+```js
+const controller = new AbortController();
+const cancelButton = document.querySelector("#cancel-tool");
+const cancelExecution = () => controller.abort();
+cancelButton?.addEventListener("click", cancelExecution, { once: true });
+
+try {
+  await document.modelContext.executeTool(tool, input, {
+    signal: controller.signal,
+  });
+} catch (error) {
+  if (!controller.signal.aborted) {
+    throw error;
+  }
+} finally {
+  cancelButton?.removeEventListener("click", cancelExecution);
+}
+```
+
 ## Example
 
 ```html

--- a/skills/webmcp/references/troubleshooting.md
+++ b/skills/webmcp/references/troubleshooting.md
@@ -10,12 +10,21 @@
 6. If only `navigator.modelContext` is present, the page is running on Chrome 146\u2013149; the deprecated `navigator.modelContext` fallback in the pattern above will pick it up. On Chrome 150+, prefer `document.modelContext`.
 7. If the feature must run in a worker or headlessly, stop and redirect the design because WebMCP does not support that mode.
 
-## `registerTool()` failures are not caught (Chrome 151+)
+## `registerTool()` failures are not caught
 
 1. Starting in Chrome `151.0.7922.0`, `registerTool()` returns a `Promise<void>`, so failures can arrive as a Promise rejection instead of a synchronous throw.
 2. Await the call inside a `try`/`catch`: `await modelContext.registerTool(tool, { signal })`. This catches both synchronous throws on older builds and Promise rejections on Chrome 151+, so it is backward compatible.
 3. If you cannot await directly (for example inside a synchronous framework effect), wrap registration in an async IIFE or attach a `.catch()` handler so rejections are not lost as unhandled promise rejections; keep `controller.abort()` cleanup synchronous.
 4. The Promise resolves only once the tool is visible to `getTools()` across the frame tree, so await it when later logic depends on the tool already being registered.
+
+## Tool cancellation does not stop work
+
+1. On Chrome `153.0.8009.0` or later, accept the always-present `{ signal }` as the second argument to the imperative tool's `execute` callback.
+2. Pass the signal to `fetch()` and other abort-aware operations.
+3. For work that is not abort-aware, check `signal.aborted` between stages and throw `signal.reason` when canceled.
+4. Do not confuse the execution signal with the registration signal: the former cancels one call, while the latter controls tool availability.
+5. Do not unregister and re-register a tool to cancel a call. Chrome 153+ intentionally leaves in-flight executions running when registration ends.
+6. If testing with the GoogleChromeLabs polyfill from PR #321, use it for local declarative cancellation only; its local imperative and remote execution paths do not fully model the Chrome 153 signal contract.
 
 ## `registerTool()` throws `InvalidStateError`
 
@@ -79,7 +88,8 @@
 
 1. Remove any use of `provideContext` or `clearContext`.
 2. Remove any use of `toolparamtitle`.
-3. Align the integration with the current WebMCP surface instead of reviving removed names.
+3. Replace `execute(input, client)` examples with `execute(input, { signal })` for Chrome 153+; do not call `client.requestUserInteraction()` from that second argument.
+4. Align the integration with the current WebMCP surface instead of reviving removed names.
 
 ## Deterministic validation is hard
 

--- a/skills/webmcp/references/webmcp-reference.md
+++ b/skills/webmcp/references/webmcp-reference.md
@@ -25,7 +25,7 @@ Use this file for the core contract before editing code.
 1. WebMCP is exposed through `document.modelContext`.
 2. `document.modelContext` is a secure-context, window-only API and is scoped per-`Document`.
 3. `Document` exposes a `modelContext` getter that returns a `ModelContext` instance for that document.
-4. The earlier `navigator.modelContext` getter is deprecated as of Chrome `150.0.7861.0` and will be removed in a future Chrome release; it remains available for now so older preview builds keep working.
+4. The earlier `navigator.modelContext` getter is deprecated and retained only as a fallback for older preview builds.
 5. Use the feature-detection pattern `const modelContext = document.modelContext || navigator.modelContext;` so the same code works on Chrome 150+ and on older 146–149 builds during the transition window. Background: WebML CG [issue 173](https://github.com/webmachinelearning/webmcp/issues/173), spec [PR #184](https://github.com/webmachinelearning/webmcp/pull/184), and demo migration in [GoogleChromeLabs/webmcp-tools PR #189](https://github.com/GoogleChromeLabs/webmcp-tools/pull/189/changes).
 
 ## Imperative API
@@ -37,12 +37,51 @@ Use this file for the core contract before editing code.
    `title`: optional `USVString` human-readable label shown in user-agent UI; should be localized; does not affect agent routing.
    `description`: natural-language description of what the tool does and when to use it (required).
    `inputSchema`: optional JSON Schema object describing the expected input; omit when the tool takes no structured input.
-   `execute`: callback invoked with the input object and a `ModelContextClient` (required).
+   `execute`: callback invoked with the input object and `ToolExecuteCallbackOptions` (required).
    `annotations.readOnlyHint`: optional boolean, defaulting to false, indicating that the tool does not modify state.
    `annotations.untrustedContentHint`: optional boolean, defaulting to false, indicating that the tool's output contains data untrusted by the registering author.
-4. The `ToolExecuteCallback` signature is `(input: object, client: ModelContextClient) => Promise<any>` and may be asynchronous.
-5. The `ModelContextClient` exposes `requestUserInteraction(callback)` for tool flows that need explicit user interaction. The `callback` is a `UserInteractionCallback`, a zero-argument async function `() => Promise<any>` that performs the user-facing step and resolves with the interaction result.
-6. Imperative tools can return structured tool output after the page has updated, including content-oriented payloads that the agent can read.
+4. Starting in Chrome `153.0.8009.0`, the `ToolExecuteCallback` signature is `(input: object, options: ToolExecuteCallbackOptions) => Promise<any>`, and `options.signal` is always present.
+5. The browser creates a fresh execution `AbortController` for each invocation. When the user or agent cancels through the caller's `executeTool(..., { signal })` signal, the tool's execution signal aborts.
+6. Destroying the caller document also cancels its pending invocation and aborts the execution signal in the tool's document.
+7. Cancellation rejects the caller's `executeTool()` promise with the caller signal's abort reason. If the tool callback later resolves or rejects, that settlement is ignored.
+8. Pass the execution signal to abort-aware work such as `fetch()` and check it between stages of custom long-running work.
+9. Unregistering a tool does not abort executions already in flight on Chrome 153+. Keep registration lifecycle cleanup separate from per-call execution cancellation.
+10. Imperative tools can return structured tool output after the page has updated, including content-oriented payloads that the agent can read.
+
+### Cancellation Example
+
+```js
+await document.modelContext.registerTool({
+  name: "fetch_tool",
+  description: "Fetch the text content of a URL and stream the response.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      url: { type: "string", description: "The URL to fetch." },
+    },
+    required: ["url"],
+  },
+  execute: async ({ url }, { signal }) => {
+    const response = await fetch(url, { signal });
+    if (!response.ok) {
+      throw new Error(`Fetch failed with status ${response.status}.`);
+    }
+
+    const output = document.querySelector("pre");
+    if (!response.body || !output) {
+      throw new Error("Streaming output is unavailable.");
+    }
+
+    const stream = response.body.pipeThrough(new TextDecoderStream());
+
+    for await (const chunk of stream) {
+      output.textContent += chunk;
+    }
+
+    return "Success";
+  },
+});
+```
 
 ## Registration Semantics
 
@@ -57,7 +96,8 @@ Use this file for the core contract before editing code.
 9. If the `AbortSignal` passed to `registerTool()` is already aborted at the time of the call, the browser silently skips registration and returns without throwing an error; it may optionally log a warning to the console. The tool will not appear in the registered tool set.
 10. The second argument to `registerTool()` also accepts `exposedTo`: an array of origin URL strings that control which documents in the page tree can see the tool. Each origin must be potentially trustworthy; passing an invalid or non-trustworthy origin throws `SecurityError`.
 11. Starting in Chrome `151.0.7922.0`, `registerTool()` returns a `Promise<void>` that resolves once the tool is registered across the frame tree and is visible to `getTools()` in other documents. Earlier builds returned `void` synchronously. Cross-origin iframe integration shares tools across the frame tree, which makes registration fundamentally asynchronous even though the failure conditions remain locally known.
-12. The failure conditions above are known synchronously (they depend only on the local per-document tool cache), but they may surface either as a synchronous throw or as a Promise rejection depending on the build. Await `registerTool()` inside a `try`/`catch` so both paths are caught; this also stays forward compatible with future asynchronous failure cases. Background: WebML CG [issue 175](https://github.com/webmachinelearning/webmcp/issues/175) and demo migration in [GoogleChromeLabs/webmcp-tools PR #228](https://github.com/GoogleChromeLabs/webmcp-tools/pull/228).
+12. The failure conditions above are known synchronously (they depend only on the local per-document tool cache), but they may surface either as a synchronous throw or as a Promise rejection depending on the build. Await `registerTool()` inside a `try`/`catch` so both paths are caught; this also stays forward compatible with future asynchronous failure cases.
+13. Starting in Chrome `153.0.8009.0`, removing a registration does not abort an execution that has already started.
 
 ## Events
 
@@ -87,5 +127,5 @@ Use this file for the core contract before editing code.
 ## Current Draft Gaps
 
 1. Declarative WebMCP is not yet as completely specified as the imperative API.
-2. `requestUserInteraction()` is defined at a high level, but some algorithmic details are still sparse.
+2. User prompting and elicitation do not yet have a standardized imperative callback in the current `execute(input, { signal })` contract.
 3. Security, privacy, and accessibility guidance exists, but it remains relatively high level.

--- a/skills/webmcp/scripts/find-webmcp-targets.mjs
+++ b/skills/webmcp/scripts/find-webmcp-targets.mjs
@@ -21,6 +21,8 @@ const WEBMCP_MARKERS = [
   "navigator.modelContext",
   "registerTool(",
   "unregisterTool(",
+  "getTools(",
+  "executeTool(",
   "toolname=",
   "tooldescription=",
   "toolautosubmit",


### PR DESCRIPTION
Chrome 153 changes the imperative WebMCP execution contract so every tool receives a per-invocation cancellation signal, while registration teardown no longer stops work already in flight. This update keeps the skill's procedures, template, compatibility notes, and troubleshooting guidance aligned with that lifecycle split.

## What changed

- Use `execute(input, { signal })`, forward the signal into abort-aware work such as `fetch()`, and remove the obsolete second-argument client pattern. [WebMCP ToolExecuteCallbackOptions](https://webmachinelearning.github.io/webmcp/#tool-execute-callback-options)
- Treat registration cleanup and invocation cancellation independently, including caller-document destruction, abort-reason propagation, and ignored late callback settlement. [WebMCP pending execution cancellation](https://webmachinelearning.github.io/webmcp/#pending-tool-executions)
- Document caller-driven declarative cancellation, `toolcancel` behavior, and the agent-loop pattern that handles cancellation separately from tool errors. [Merged agent sample](https://github.com/GoogleChromeLabs/webmcp-tools/blob/0d67b3db0efd8ac4344dc6c2767306d3d972f15c/demos/french-bistro/agent.js#L117-L141)
- Call out that the linked polyfill covers local declarative cancellation but does not fully model native imperative or remote cancellation, preventing false-positive compatibility validation. [Merged polyfill implementation](https://github.com/GoogleChromeLabs/webmcp-tools/blob/0d67b3db0efd8ac4344dc6c2767306d3d972f15c/demos/shared/webmcp-polyfill.js#L249-L374)
- Expand the target finder to recognize in-page `getTools()` and `executeTool()` integration points used by cancellation-aware agents. [WebMCP executeTool API](https://webmachinelearning.github.io/webmcp/#dom-modelcontext-executetool)

The skill metadata version is bumped to 1.6 to reflect the changed agent-facing contract.